### PR TITLE
Implement registration, login and Express API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dist-ssr
 *.sln
 *.sw?
 .env
+guild.db
+.env

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lowcalibre Guild Recruitment Portal
 
-This project is a prototype recruitment dashboard for the Lowcalibre guild. It is built with **React** and **TypeScript** using [Vite](https://vitejs.dev/) and styled with **Tailwind CSS**.
+This project is a recruitment dashboard for the Lowcalibre guild. The frontend is built with **React** and **TypeScript** using [Vite](https://vitejs.dev/). An **Express** API backed by **SQLite** handles authentication and stores applications.
 
 ## Getting Started
 
@@ -16,16 +16,23 @@ npm install
 npm run dev
 ```
 
+3. In a separate terminal, start the API server:
+
+```bash
+npm run server
+```
+
 The app will be available at `http://localhost:5173` by default.
 
 ## Available Scripts
 
-- `npm run dev` &ndash; start the Vite development server
-- `npm run build` &ndash; create a production build in the `dist` folder
-- `npm run preview` &ndash; preview the production build locally
-- `npm test` &ndash; run unit tests with [Vitest](https://vitest.dev/)
-- `npm run lint` &ndash; lint the codebase using ESLint
+- `npm run dev` – start the Vite development server
+- `npm run server` – start the Express API server
+- `npm run build` – create a production build in the `dist` folder
+- `npm run preview` – preview the production build locally
+- `npm test` – run unit tests with [Vitest](https://vitest.dev/)
+- `npm run lint` – lint the codebase using ESLint
 
 ## Notes
 
-The project currently uses mocked data and authentication for demonstration purposes. In a real deployment these would be replaced with proper API calls and secure authentication.
+The API server stores data in a local SQLite database located at `guild.db`. In production you may wish to migrate this to PostgreSQL or another managed service.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
     "dev": "vite --host",
+    "server": "ts-node server/index.ts",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
@@ -25,7 +25,12 @@
     "sonner": "^1.4.0",
     "zustand": "^4.5.0",
     "clsx": "^2.1.0",
-    "tailwind-merge": "^2.2.1"
+    "tailwind-merge": "^2.2.1",
+    "express": "^4.19.2",
+    "sqlite3": "^5.1.6",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.2",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
@@ -43,6 +48,12 @@
     "typescript-eslint": "^8.3.0",
     "vite": "^5.4.2",
     "vitest": "^1.2.1",
-    "msw": "^2.1.5"
+    "msw": "^2.1.5",
+    "ts-node": "^10.9.1",
+    "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.2",
+    "@types/bcryptjs": "^2.4.2",
+    "@types/cors": "^2.8.13",
+    "@types/node": "^20.11.30"
   }
 }

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,0 +1,73 @@
+import sqlite3 from 'sqlite3';
+import { open, Database } from 'sqlite';
+import path from 'path';
+
+export interface User {
+  id: number;
+  username: string;
+  passwordHash: string;
+  role: 'candidate' | 'officer';
+}
+
+export interface Application {
+  id: number;
+  userId: number;
+  battletag: string;
+  charName: string;
+  realm: string;
+  charClass: string;
+  spec: string;
+  desiredRole: string;
+  experience?: string;
+  ui?: string;
+  addons?: string;
+  availability: string;
+  reason: string;
+  referral?: string;
+  status: string;
+  officerNotes?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+let db: Database<sqlite3.Database, sqlite3.Statement>;
+
+export const initDb = async () => {
+  db = await open({
+    filename: path.join(process.cwd(), 'guild.db'),
+    driver: sqlite3.Database,
+  });
+
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT UNIQUE NOT NULL,
+      passwordHash TEXT NOT NULL,
+      role TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS applications (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      userId INTEGER NOT NULL,
+      battletag TEXT NOT NULL,
+      charName TEXT NOT NULL,
+      realm TEXT NOT NULL,
+      charClass TEXT NOT NULL,
+      spec TEXT NOT NULL,
+      desiredRole TEXT NOT NULL,
+      experience TEXT,
+      ui TEXT,
+      addons TEXT,
+      availability TEXT NOT NULL,
+      reason TEXT NOT NULL,
+      referral TEXT,
+      status TEXT NOT NULL,
+      officerNotes TEXT,
+      createdAt TEXT NOT NULL,
+      updatedAt TEXT NOT NULL,
+      FOREIGN KEY(userId) REFERENCES users(id)
+    );
+  `);
+};
+
+export const getDb = () => db;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,105 @@
+import express from 'express';
+import cors from 'cors';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import { initDb, getDb, User, Application } from './db';
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+const JWT_SECRET = process.env.JWT_SECRET || 'change-me';
+
+app.use(cors());
+app.use(express.json());
+
+const authMiddleware = (roles?: string[]) => {
+  return (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    const auth = req.headers.authorization;
+    if (!auth) return res.status(401).json({ message: 'Missing token' });
+    const token = auth.replace('Bearer ', '');
+    try {
+      const decoded = jwt.verify(token, JWT_SECRET) as { id: number; role: string };
+      (req as any).user = decoded;
+      if (roles && !roles.includes(decoded.role)) {
+        return res.status(403).json({ message: 'Forbidden' });
+      }
+      next();
+    } catch (err) {
+      res.status(401).json({ message: 'Invalid token' });
+    }
+  };
+};
+
+app.post('/api/register', async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) return res.status(400).json({ message: 'Missing fields' });
+  const db = getDb();
+  const existing = await db.get<User>('SELECT * FROM users WHERE username = ?', username);
+  if (existing) return res.status(409).json({ message: 'User exists' });
+  const passwordHash = await bcrypt.hash(password, 10);
+  const result = await db.run('INSERT INTO users (username, passwordHash, role) VALUES (?,?,?)', username, passwordHash, 'candidate');
+  const user = { id: result.lastID!, username, role: 'candidate' };
+  const token = jwt.sign(user, JWT_SECRET, { expiresIn: '1d' });
+  res.json({ token, user });
+});
+
+app.post('/api/login', async (req, res) => {
+  const { username, password } = req.body;
+  const db = getDb();
+  const user = await db.get<User>('SELECT * FROM users WHERE username = ?', username);
+  if (!user) return res.status(401).json({ message: 'Invalid credentials' });
+  const match = await bcrypt.compare(password, user.passwordHash);
+  if (!match) return res.status(401).json({ message: 'Invalid credentials' });
+  const token = jwt.sign({ id: user.id, username: user.username, role: user.role }, JWT_SECRET, { expiresIn: '1d' });
+  res.json({ token, user: { id: user.id, username: user.username, role: user.role } });
+});
+
+app.post('/api/applications', authMiddleware(), async (req, res) => {
+  const user = (req as any).user as User;
+  const data = req.body as Partial<Application>;
+  const db = getDb();
+  const now = new Date().toISOString();
+  const result = await db.run(
+    `INSERT INTO applications (userId, battletag, charName, realm, charClass, spec, desiredRole, experience, ui, addons, availability, reason, referral, status, createdAt, updatedAt)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    user.id,
+    data.battletag,
+    data.charName,
+    data.realm,
+    data.charClass,
+    data.spec,
+    data.desiredRole,
+    data.experience || null,
+    data.ui || null,
+    data.addons || null,
+    data.availability,
+    data.reason,
+    data.referral || null,
+    'New',
+    now,
+    now,
+  );
+  const appId = result.lastID!;
+  const application = await db.get<Application>('SELECT * FROM applications WHERE id = ?', appId);
+  res.json(application);
+});
+
+app.get('/api/applications', authMiddleware(['officer']), async (req, res) => {
+  const db = getDb();
+  const apps = await db.all<Application[]>('SELECT * FROM applications');
+  res.json(apps);
+});
+
+app.put('/api/applications/:id/status', authMiddleware(['officer']), async (req, res) => {
+  const { id } = req.params;
+  const { status, officerNotes } = req.body;
+  const db = getDb();
+  await db.run('UPDATE applications SET status = ?, officerNotes = ?, updatedAt = ? WHERE id = ?', status, officerNotes || null, new Date().toISOString(), id);
+  const application = await db.get<Application>('SELECT * FROM applications WHERE id = ?', id);
+  res.json(application);
+});
+
+initDb().then(() => {
+  app.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import { Toaster } from 'sonner';
 import LandingPage from './pages/LandingPage';
 import ApplicationPage from './pages/ApplicationPage';
 import SuccessPage from './pages/SuccessPage';
+import RegisterPage from './pages/RegisterPage';
+import CandidateLogin from './pages/CandidateLogin';
 import AdminDashboard from './pages/AdminDashboard';
 import AdminLogin from './pages/AdminLogin';
 import NotFoundPage from './pages/NotFoundPage';
@@ -25,16 +27,18 @@ function App() {
         <Routes>
           <Route element={<Layout />}>
             <Route path="/" element={<LandingPage />} />
-            <Route path="/apply" element={<ApplicationPage />} />
+            <Route path="/apply" element={<ProtectedRoute redirect='/login'><ApplicationPage /></ProtectedRoute>} />
+            <Route path="/login" element={<CandidateLogin />} />
+            <Route path="/register" element={<RegisterPage />} />
             <Route path="/success" element={<SuccessPage />} />
             <Route path="/admin/login" element={<AdminLogin />} />
-            <Route 
-              path="/admin/*" 
+            <Route
+              path="/admin/*"
               element={
-                <ProtectedRoute>
+                <ProtectedRoute redirect="/admin/login" roles={['officer']}>
                   <AdminDashboard />
                 </ProtectedRoute>
-              } 
+              }
             />
             <Route path="*" element={<NotFoundPage />} />
           </Route>

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -5,10 +5,12 @@ import LoadingSpinner from '../ui/LoadingSpinner';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
+  redirect?: string;
+  roles?: string[];
 }
 
-const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
-  const { isAuthenticated, isLoading } = useAuth();
+const ProtectedRoute = ({ children, redirect = '/admin/login', roles }: ProtectedRouteProps) => {
+  const { isAuthenticated, isLoading, user } = useAuth();
   const location = useLocation();
 
   if (isLoading) {
@@ -20,7 +22,11 @@ const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
   }
 
   if (!isAuthenticated) {
-    return <Navigate to="/admin/login" state={{ from: location }} replace />;
+    return <Navigate to={redirect} state={{ from: location }} replace />;
+  }
+
+  if (roles && user && !roles.includes(user.role)) {
+    return <Navigate to={redirect} replace />;
   }
 
   return <>{children}</>;

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -81,12 +81,11 @@ const Navbar = () => {
                 </button>
               </>
             ) : (
-              <Link 
-                to="/admin/login" 
-                className="btn btn-primary"
-              >
-                Officer Login
-              </Link>
+              <>
+                <Link to="/login" className="btn btn-primary">Login</Link>
+                <Link to="/register" className="btn btn-secondary">Register</Link>
+                <Link to="/admin/login" className="btn btn-outline">Officer Login</Link>
+              </>
             )}
           </div>
           
@@ -147,13 +146,29 @@ const Navbar = () => {
                 </button>
               </>
             ) : (
-              <Link
-                to="/admin/login"
-                onClick={() => setIsOpen(false)}
-                className="block px-3 py-2 rounded-md text-center font-medium bg-primary text-background-light"
-              >
-                Officer Login
-              </Link>
+              <>
+                <Link
+                  to="/login"
+                  onClick={() => setIsOpen(false)}
+                  className="block px-3 py-2 rounded-md font-medium text-center text-gray-300 hover:text-primary"
+                >
+                  Login
+                </Link>
+                <Link
+                  to="/register"
+                  onClick={() => setIsOpen(false)}
+                  className="block px-3 py-2 rounded-md font-medium text-center text-gray-300 hover:text-primary"
+                >
+                  Register
+                </Link>
+                <Link
+                  to="/admin/login"
+                  onClick={() => setIsOpen(false)}
+                  className="block px-3 py-2 rounded-md text-center font-medium bg-primary text-background-light"
+                >
+                  Officer Login
+                </Link>
+              </>
             )}
           </div>
         </div>

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,27 +1,26 @@
 import React, { useState, useEffect } from 'react';
-import { Routes, Route, useNavigate } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { toast } from 'sonner';
 import ApplicantList from '../components/admin/ApplicantList';
 import ApplicantDetails from '../components/admin/ApplicantDetails';
 import DashboardStats from '../components/admin/DashboardStats';
 import { Applicant } from '../types';
-import { mockApplicants } from '../data/mockData';
+import axios from 'axios';
 
 const AdminDashboard = () => {
   const [applicants, setApplicants] = useState<Applicant[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const { user, logout } = useAuth();
-  const navigate = useNavigate();
+  const { user, token } = useAuth();
 
   useEffect(() => {
     const fetchApplicants = async () => {
       setIsLoading(true);
       try {
-        // This would be an API call in production
-        // Simulating API delay
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        setApplicants(mockApplicants);
+        const res = await axios.get('/api/applications', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        setApplicants(res.data);
       } catch (error) {
         console.error('Error fetching applicants:', error);
         toast.error('Failed to load applicant data');
@@ -35,13 +34,10 @@ const AdminDashboard = () => {
 
   const updateApplicantStatus = async (id: string, status: string, notes?: string) => {
     try {
-      // This would be an API call in production
-      setApplicants(applicants.map(app => 
-        app.id === id 
-          ? { ...app, status: status as any, officerNotes: notes || app.officerNotes } 
-          : app
-      ));
-      
+      const res = await axios.put(`/api/applications/${id}/status`, { status, officerNotes: notes }, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setApplicants(applicants.map(app => app.id === id ? res.data : app));
       toast.success(`Applicant status updated to ${status}`);
       return true;
     } catch (error) {

--- a/src/pages/ApplicationPage.tsx
+++ b/src/pages/ApplicationPage.tsx
@@ -7,6 +7,8 @@ import { toast } from 'sonner';
 import { CharacterClass, CharacterRole } from '../types';
 import { Search } from 'lucide-react';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
+import axios from 'axios';
+import { useAuth } from '../contexts/AuthContext';
 
 // Form validation schema
 const applicationSchema = z.object({
@@ -30,6 +32,7 @@ const ApplicationPage = () => {
   const [isSearchingCharacter, setIsSearchingCharacter] = useState(false);
   const [characterFound, setCharacterFound] = useState(false);
   const navigate = useNavigate();
+  const { token } = useAuth();
   
   const { 
     register, 
@@ -122,13 +125,9 @@ const ApplicationPage = () => {
   // Form submission handler
   const onSubmit = async (data: ApplicationFormValues) => {
     try {
-      // This would be an API call in production
-      console.log('Application data:', data);
-      
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      
-      // Success
+      await axios.post('/api/applications', data, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
       toast.success('Application submitted successfully!');
       navigate('/success');
     } catch (error) {

--- a/src/pages/CandidateLogin.tsx
+++ b/src/pages/CandidateLogin.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { LogIn } from 'lucide-react';
+import { useAuth } from '../contexts/AuthContext';
+import { toast } from 'sonner';
+
+const CandidateLogin = () => {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const from = (location.state as { from?: { pathname: string } })?.from?.pathname || '/apply';
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    const success = await login(username, password);
+    if (success) {
+      toast.success('Logged in');
+      navigate(from, { replace: true });
+    } else {
+      toast.error('Invalid credentials');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="min-h-screen pt-24 pb-20 flex items-center justify-center">
+      <div className="container mx-auto px-4 max-w-md card">
+        <h1 className="text-2xl font-display text-primary mb-6 text-center">Login</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="username" className="block text-sm font-medium text-gray-300 mb-1">Username</label>
+            <input id="username" className="input w-full" value={username} onChange={e => setUsername(e.target.value)} required />
+          </div>
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-1">Password</label>
+            <input id="password" type="password" className="input w-full" value={password} onChange={e => setPassword(e.target.value)} required />
+          </div>
+          <button type="submit" disabled={loading} className="btn btn-primary w-full flex items-center justify-center gap-2">
+            {loading ? 'Logging in...' : (<><LogIn size={16} /><span>Login</span></>)}
+          </button>
+        </form>
+        <p className="text-center text-sm text-gray-400 mt-4">No account? <Link to="/register" className="text-primary">Register</Link></p>
+      </div>
+    </div>
+  );
+};
+
+export default CandidateLogin;

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { toast } from 'sonner';
+
+const RegisterPage = () => {
+  const { register: registerUser } = useAuth();
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    const success = await registerUser(username, password);
+    if (success) {
+      toast.success('Account created');
+      navigate('/apply');
+    } else {
+      toast.error('Registration failed');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="min-h-screen pt-24 pb-20 flex justify-center items-center">
+      <div className="container mx-auto px-4 max-w-md card">
+        <h1 className="text-2xl font-display text-primary mb-6 text-center">Create Account</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="username" className="block text-sm font-medium text-gray-300 mb-1">Username</label>
+            <input id="username" className="input w-full" value={username} onChange={e => setUsername(e.target.value)} required />
+          </div>
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-1">Password</label>
+            <input id="password" type="password" className="input w-full" value={password} onChange={e => setPassword(e.target.value)} required />
+          </div>
+          <button type="submit" disabled={loading} className="btn btn-primary w-full">{loading ? 'Creating...' : 'Register'}</button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default RegisterPage;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,9 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3001',
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- add Express server with SQLite persistence
- implement user auth & application API endpoints
- allow candidates to register/login and submit applications
- officers can review and update applications
- hook up frontend to API and add candidate login page
- update README with server usage instructions

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint module not found)*